### PR TITLE
Restore Genius Enhancer extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,21 @@ or
 
 1. Clone the repository
 ```
-git clone https://github.com/Uri6/Genius-Enhancer.git
+git clone https://github.com/hackeagle/Genius-Enhancer.git
 ```
 
-2. Compile the scss files
-3. Add your own API keys to the secrets.example.js file and rename it to secrets.js
-4. Load the extension in Chrome
+2. Install dependencies with `yarn install`
+3. Compile the styles with `yarn build`
+4. Optional: add Google or Spotify credentials to
+   `src/js/extension/defaultSecrets.js` for local testing. Do not commit real
+   credentials. The extension loads with those integrations disabled when the
+   values are blank.
+5. Load the extension in Chrome
     - Open up `chrome://extensions/` in your browser and click `Developer mode` in the top right
     - Click `Load unpacked` and select the `Genius-Enhancer` directory
+
+Run `yarn check` after making changes. It verifies the JavaScript project and
+ensures every file referenced by the extension exists.
 
 ## Usage
 1. Go to Genius.com

--- a/background.js
+++ b/background.js
@@ -47,19 +47,61 @@ import { handleForumsMain } from "./src/js/pages/forumsMain.js";
 import { handlePenalties } from "./src/js/pages/mecha.penalties.js";
 import { geniusGlobalContentScript } from "./src/js/globalContent.js";
 
-function getTabId() {
-    return new Promise((resolve, reject) => {
-        try {
-            chrome.tabs.query({
-                active: true
-            }, (tabs) => {
-                resolve(tabs[0].id);
-            });
-        } catch (e) {
-            reject(e);
-        }
+async function getTabId(sender) {
+    if (sender?.tab?.id !== undefined) {
+        return sender.tab.id;
+    }
+    const tabs = await chrome.tabs.query({
+        active: true,
+        currentWindow: true
     });
+    return tabs[0]?.id;
 }
+
+function isInjectableGeniusUrl(tabUrl) {
+    try {
+        const parsed = new URL(tabUrl);
+        return parsed.protocol === "https:" &&
+            (parsed.hostname === "genius.com" || parsed.hostname === "www.genius.com");
+    } catch {
+        return false;
+    }
+}
+
+const defaultSettings = {
+    bios: true,
+    people: true,
+    releaseDate: true,
+    appleMusicPopUp: true,
+    spotifyPopUp: true,
+    soundCloudPopUp: true,
+    add_song_as_next: true,
+    ModernTextEditor: false,
+    extensionStatus: true,
+    OldSongPage: false,
+    darkMode: false,
+    powerbarStatus: true,
+    openPowerbarResultsInNewTab: false,
+    defaultSearchType: "multi",
+    powerbarHotkey: "Shift + Shift",
+    songHeadersLanguage: "songsLang",
+    modernAddASong: true,
+    modernForums: true
+};
+
+async function initializeMissingSettings() {
+    const currentSettings = await chrome.storage.local.get(Object.keys(defaultSettings));
+    const missingSettings = Object.fromEntries(
+        Object.entries(defaultSettings).filter(([key]) => currentSettings[key] === undefined)
+    );
+    if (Object.keys(missingSettings).length) {
+        await chrome.storage.local.set(missingSettings);
+    }
+}
+
+initializeMissingSettings().catch((error) => {
+    console.error("Failed to initialize Genius Enhancer settings", error);
+});
 
 chrome.runtime.onInstalled.addListener(async (details) => {
     const currentVersion = chrome.runtime.getManifest().version;
@@ -68,24 +110,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 
     switch (reason) {
         case "install":
-            chrome.storage.local.set({ "bios": true });
-            chrome.storage.local.set({ "people": true });
-            chrome.storage.local.set({ "releaseDate": true });
-            chrome.storage.local.set({ "appleMusicPopUp": true });
-            chrome.storage.local.set({ "spotifyPopUp": true });
-            chrome.storage.local.set({ "soundCloudPopUp": true });
-            chrome.storage.local.set({ "add_song_as_next": true });
-            chrome.storage.local.set({ "ModernTextEditor": false });
-            chrome.storage.local.set({ "extensionStatus": true });
-            chrome.storage.local.set({ "OldSongPage": false });
-            chrome.storage.local.set({ "darkMode": false });
-            chrome.storage.local.set({ "powerbarStatus": true });
-            chrome.storage.local.set({ "openPowerbarResultsInNewTab": false });
-            chrome.storage.local.set({ "defaultSearchType": "multi" });
-            chrome.storage.local.set({ "powerbarHotkey": "Shift + Shift" });
-            chrome.storage.local.set({ "songHeadersLanguage": "songsLang" });
-            chrome.storage.local.set({ "modernAddASong": true });
-            chrome.storage.local.set({ "modernForums": true });
+            await chrome.storage.local.set(defaultSettings);
             break;
         case "update":
             if (previousVersion) {
@@ -160,7 +185,18 @@ async function getReleaseNotes(versions) {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    getTabId().then((tabId) => {
+    getTabId(sender).then(async (tabId) => {
+        if (tabId === undefined) {
+            sendResponse(undefined);
+            return;
+        }
+
+        const targetTab = sender?.tab || await chrome.tabs.get(tabId);
+        if (!isInjectableGeniusUrl(targetTab?.url)) {
+            sendResponse(undefined);
+            return;
+        }
+
         const functions = {
             fixNonLatin: [fixNonLatin, message.fixNonLatin],
             getDetails: [getDetails, [""]],
@@ -188,33 +224,36 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         const [func, args] = functions[Object.keys(message)[0]] || [];
 
         if (!func) {
+            sendResponse(undefined);
             return;
         }
 
-        chrome.scripting.executeScript({
+        const results = await chrome.scripting.executeScript({
             target: { tabId: tabId },
             func: func,
             args: args
-        }).then((results) => {
-            const res = (func === autolinkArtwork ||
-                func === identifyPageType ||
-                func === getPlaylistVideos ||
-                func === getDetails ||
-                func === getArtistsList ||
-                func === getCreditsList ||
-                func === searchVideo ||
-                func === fixNonLatin) ? results[0].result : undefined;
-
-            console.info("----------------------------------------");
-            console.info("%c new message received ", "background-color: #ff1464; color: #fff; padding: 5px; text-align: center; font-size: 15px; font-weight: bold; display: block; border-radius: 5px;");
-            console.info("time received: ", new Date().toLocaleTimeString("en-US", { hour12: false }));
-            console.info("message received: ", message);
-            console.info("function called: ", func.name);
-            console.info("arguments: ", args);
-            console.info("response: ", res);
-
-            sendResponse(res);
         });
+        const res = (func === autolinkArtwork ||
+            func === identifyPageType ||
+            func === getPlaylistVideos ||
+            func === getDetails ||
+            func === getArtistsList ||
+            func === getCreditsList ||
+            func === searchVideo ||
+            func === fixNonLatin) ? results[0]?.result : undefined;
+
+        console.info("----------------------------------------");
+        console.info("%c new message received ", "background-color: #ff1464; color: #fff; padding: 5px; text-align: center; font-size: 15px; font-weight: bold; display: block; border-radius: 5px;");
+        console.info("time received: ", new Date().toLocaleTimeString("en-US", { hour12: false }));
+        console.info("message received: ", message);
+        console.info("function called: ", func.name);
+        console.info("arguments: ", args);
+        console.info("response: ", res);
+
+        sendResponse(res);
+    }).catch((error) => {
+        console.warn("Genius Enhancer could not handle a page message", error);
+        sendResponse(undefined);
     });
 
     return true;
@@ -443,7 +482,7 @@ const files = [
     },
     {
         type: "js",
-        file: "./secrets.js"
+        file: "./src/js/extension/defaultSecrets.js"
     },
     {
         type: "js",
@@ -488,10 +527,17 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     chrome.storage.local.get("extensionStatus", async (res) => {
         if (res.extensionStatus) {
             // we might not have access to this page
-            isGeniusPage = geniusAddress.some((adress) => tab?.url?.startsWith(adress));
+            let parsedUrl;
+            try {
+                parsedUrl = new URL(tab?.url);
+            } catch {
+                parsedUrl = null;
+            }
+            isGeniusPage = parsedUrl?.protocol === "https:" &&
+                (parsedUrl.hostname === "genius.com" || parsedUrl.hostname === "www.genius.com");
             await chrome.storage.local.set({ "isGeniusPage": isGeniusPage });
 
-            if (!tab.url) {
+            if (!tab.url || changeInfo.status !== "complete" || !isGeniusPage) {
                 return;
             }
 
@@ -507,32 +553,40 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
             pageType = "unknown";
 
-            const prohibitedDomains = ["promote.genius.com", "support.genius.com", "docs.genius.com", "homestudio.genius.com", "genius.com/developers", "genius.com/api-clients", "api.genius.com"];
+            const prohibitedDomains = [
+                "promote.genius.com",
+                "support.genius.com",
+                "docs.genius.com",
+                "homestudio.genius.com",
+                "api.genius.com"
+            ];
+            const prohibitedPaths = ["/developers", "/api-clients"];
 
-            const protocolAndDomainRegex = /^https:\/\/([^\/]+)/;
-            const protocolAndDomainMatch = tab.url.match(protocolAndDomainRegex);
-
-            if (protocolAndDomainMatch !== null && prohibitedDomains.includes(protocolAndDomainMatch[1])) {
+            if (prohibitedDomains.includes(parsedUrl.hostname) ||
+                prohibitedPaths.some((path) => parsedUrl.pathname.startsWith(path))) {
                 return;
             }
 
-            if (changeInfo.status !== "complete" || !tab.url.includes("genius.com")) {
-                return;
-            }
-
-            const runningFlag = await chrome.scripting.executeScript({
-                target: { tabId: tabId },
-                func: () => {
-                    if (document.body.dataset.geniusEnhancerRunning === "true") {
-                        return false;
-                    } else {
-                        document.body.dataset.geniusEnhancerRunning = "true";
-                        return true;
+            let runningFlag;
+            try {
+                runningFlag = await chrome.scripting.executeScript({
+                    target: { tabId: tabId },
+                    func: () => {
+                        if (document.body.dataset.geniusEnhancerUrl === location.href) {
+                            return false;
+                        } else {
+                            document.body.dataset.geniusEnhancerRunning = "true";
+                            document.body.dataset.geniusEnhancerUrl = location.href;
+                            return true;
+                        }
                     }
-                }
-            });
+                });
+            } catch (error) {
+                console.warn("Genius Enhancer could not access this tab", error);
+                return;
+            }
 
-            if (!runningFlag[0].result) {
+            if (!runningFlag?.[0]?.result) {
                 return;
             }
 
@@ -558,9 +612,10 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
                     return undefined;
                 }
 
-                const urlPart = tab.url.split("genius.com/")[1];
+                const currentUrl = new URL(tab.url);
+                const urlPart = currentUrl.pathname.replace(/^\/|\/$/g, "");
 
-                if (!urlPart.includes("/") && (urlPart.endsWith("-lyrics") || urlPart.endsWith("-annotated") || urlPart.endsWith("?react=1") || urlPart.endsWith("?bagon=1"))) {
+                if (!urlPart.includes("/") && (urlPart.endsWith("-lyrics") || urlPart.endsWith("-annotated"))) {
                     // we may not reach the end of the function by the time chrome updates. just in case!
                     pageType = "song";
 
@@ -579,14 +634,24 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
                     });
 
                     return "song";
-                } else if (geniusAddress.some((address) => tab.url === address) || (urlPart[0] === "#" && !urlPart.includes("/"))) {
+                } else if (currentUrl.pathname === "/" || (currentUrl.hash && !urlPart.includes("/"))) {
                     return "home";
-                } else if (geniusAddress.some((address) => tab.url.startsWith(address + "firehose"))) {
+                } else if (urlPart === "firehose" || urlPart.startsWith("firehose/")) {
                     return "firehose";
-                } else if (geniusAddress.some((address) => tab.url === address + "new" || tab.url === address + "new/" || tab.url === address + "songs/new" || tab.url === address + "songs/new/")) {
+                } else if (urlPart === "new" || urlPart === "songs/new") {
                     return "new song";
-                } else if (geniusAddress.some((address) => tab.url.startsWith(address + "penalties"))) {
+                } else if (urlPart === "penalties" || urlPart.startsWith("penalties/")) {
                     return "mecha.penalties";
+                } else if (urlPart === "albums" || urlPart.startsWith("albums/")) {
+                    return "album";
+                } else if (urlPart === "forums") {
+                    return "forums (main)";
+                } else if (urlPart.includes("/discussions/")) {
+                    return "forum thread";
+                } else if (urlPart.startsWith("forums/") && urlPart.endsWith("/new")) {
+                    return "new post";
+                } else if (urlPart.startsWith("forums/")) {
+                    return "forum";
                 }
 
                 const isForumPage = await chrome.scripting.executeScript({
@@ -617,31 +682,51 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
                 return enabled;
             }
 
-            const cssFiles = files
-                .filter((f) => f.type === "css" && applicable(f))
+            const applicableFiles = (await Promise.all(
+                files.map(async (file) => ({
+                    file,
+                    enabled: await applicable(file)
+                }))
+            ))
+                .filter(({ enabled }) => enabled)
+                .map(({ file }) => file);
+
+            const cssFiles = applicableFiles
+                .filter((f) => f.type === "css")
                 .map((f) => f.file);
 
-            const baseJsFiles = files
-                .filter((f) => f.type === "js" && applicable(f))
+            const baseJsFiles = applicableFiles
+                .filter((f) => f.type === "js")
                 .map((f) => f.file);
 
             console.info("css files: ", cssFiles);
             console.info("js files: ", baseJsFiles);
 
             // inject relevant css/js files
-            if (cssFiles.length) {
-                await chrome.scripting.insertCSS({
-                    target: { tabId: tabId }, files: cssFiles
-                });
-            }
+            try {
+                if (cssFiles.length) {
+                    await chrome.scripting.insertCSS({
+                        target: { tabId: tabId }, files: cssFiles
+                    });
+                }
 
-            if (baseJsFiles.length) {
+                if (baseJsFiles.length) {
+                    await chrome.scripting.executeScript({
+                        target: { tabId: tabId }, files: baseJsFiles
+                    });
+                }
+
+                await handleGeniusPage(tabId);
+            } catch (error) {
+                console.error("Genius Enhancer failed to initialize this page", error);
                 await chrome.scripting.executeScript({
-                    target: { tabId: tabId }, files: baseJsFiles
-                });
+                    target: { tabId },
+                    func: () => {
+                        delete document.body.dataset.geniusEnhancerRunning;
+                        delete document.body.dataset.geniusEnhancerUrl;
+                    }
+                }).catch(() => {});
             }
-
-            await handleGeniusPage(tabId);
         }
     });
 });

--- a/compileAllSass.js
+++ b/compileAllSass.js
@@ -1,36 +1,35 @@
-// find every sass file in the project, and run the postcssCompile script on it
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
 
-const fs = require('fs');
-const path = require('path');
+function findSassFiles(directory, files = []) {
+    for (const entry of fs.readdirSync(directory)) {
+        const filePath = path.join(directory, entry);
+        const stats = fs.statSync(filePath);
 
-const walkSync = (dir, filelist = []) => {
-    // get all files in the directory
-    fs.readdirSync(dir).forEach((file) => {
-        // get the full path of the file
-        const filePath = path.join(dir, file);
-        // get the file's stats
-        const fileStat = fs.statSync(filePath);
-        // if the file is a directory, recurse into it
-        if (fileStat.isDirectory()) {
-            filelist = walkSync(filePath, filelist);
-        } else {
-            // if the file is a scss file, add it to the list
-            if (path.extname(filePath) === '.scss') {
-                filelist.push(filePath);
+        if (stats.isDirectory()) {
+            if (![".git", ".yarn", "Builds", "node_modules"].includes(entry)) {
+                findSassFiles(filePath, files);
             }
+        } else if (path.extname(filePath) === ".scss") {
+            files.push(filePath);
         }
-    })
-    return filelist;
+    }
+
+    return files;
 }
 
-// get all the scss files in the project
-const scssFiles = walkSync(__dirname);
+const compiler = path.join(__dirname, "postcssCompile.js");
 
-const child_process = require('child_process');
+for (const scssFile of findSassFiles(__dirname)) {
+    const targetFile = scssFile.replace(/\.scss$/, ".css");
+    console.log(`Compiling ${path.relative(__dirname, scssFile)}`);
 
-// for each scss file, run the postcssCompile script on it
-scssFiles.forEach((scssFile) => {
-    console.log(`:compile ${scssFile}`);
-    const targetFile = scssFile.replace('.scss', '.css');
-    child_process.execSync(`node postcssCompile.js ${scssFile} ${targetFile}`);
-})
+    const result = spawnSync(process.execPath, [compiler, scssFile, targetFile], {
+        stdio: "inherit"
+    });
+
+    if (result.status !== 0) {
+        process.exit(result.status || 1);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
         "tabWidth": 4
     },
     "scripts": {
+        "build": "node compileAllSass.js && node scripts/validate-extension.js",
+        "check": "tsc --noEmit && node scripts/validate-extension.js",
+        "validate": "node scripts/validate-extension.js",
         "prettier": "prettier --write \"**/*.{js,ts,tsx,html,json}\""
     },
     "dependencies": {

--- a/postcssCompile.js
+++ b/postcssCompile.js
@@ -1,30 +1,24 @@
-// this script gets a scss file name and the target output filename as cli inputs
-// and compiles and runs autoprefixer on the scss file and outputs the result to the target file
+const fs = require("fs");
+const path = require("path");
+const postcss = require("postcss");
+const autoprefixer = require("autoprefixer");
+const sass = require("sass");
 
-const fs = require('fs')
-const path = require('path')
-const postcss = require('postcss')
-const autoprefixer = require('autoprefixer')
-const sass = require('sass')
+const scssFile = process.argv[2];
+const targetFile = process.argv[3];
 
-const scssFile = process.argv[2]
-const targetFile = process.argv[3]
+async function compile() {
+    const result = sass.compile(scssFile, {
+        loadPaths: [path.dirname(scssFile)],
+        style: "expanded"
+    });
+    const processed = await postcss([autoprefixer()])
+        .process(result.css, { from: scssFile, to: targetFile });
 
-const result = sass.compile(scssFile, {
-    loadPaths: [path.dirname(scssFile)],
-    style: 'expanded',
-})
+    fs.writeFileSync(targetFile, processed.css);
+}
 
-postcss([autoprefixer()])
-    .process(result.css, { from: undefined })
-    .then((result) => {
-        // write the result to the target file
-        fs.writeFile(targetFile, result.css, (error) => {
-            if (error) {
-                console.error(error)
-            }
-        })
-    })
-    .catch((error) => {
-        console.error(error)
-    })
+compile().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/scripts/validate-extension.js
+++ b/scripts/validate-extension.js
@@ -1,0 +1,59 @@
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const manifest = JSON.parse(fs.readFileSync(path.join(root, "manifest.json"), "utf8"));
+const backgroundPath = path.join(root, manifest.background.service_worker);
+const background = fs.readFileSync(backgroundPath, "utf8");
+
+const referencedPaths = new Set([
+    manifest.background.service_worker,
+    manifest.action.default_popup,
+    manifest.options_page,
+    ...Object.values(manifest.icons || {}),
+    ...Object.values(manifest.action.default_icon || {})
+]);
+
+function walk(directory, files = []) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        if ([".git", ".yarn", "Builds", "node_modules"].includes(entry.name)) continue;
+        const entryPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) walk(entryPath, files);
+        else files.push(entryPath);
+    }
+    return files;
+}
+
+for (const sourcePath of walk(root).filter((file) => /\.(?:js|html)$/.test(file))) {
+    const source = fs.readFileSync(sourcePath, "utf8");
+    for (const match of source.matchAll(/["'](?:\.{1,2}\/|\/)((?:src|lib)\/[^"'?#]+\.(?:css|html|js|json|png|svg))["']/g)) {
+        let referenced = match[1];
+        if (match[0].startsWith('"../') || match[0].startsWith("'../")) {
+            referenced = path.relative(root, path.resolve(path.dirname(sourcePath), match[0].slice(1, -1)));
+        }
+        referencedPaths.add(referenced.replaceAll("\\", "/"));
+    }
+
+    if (sourcePath.endsWith(".html")) {
+        for (const match of source.matchAll(/(?:src|href)=["']([^"'?#]+)["']/g)) {
+            const value = match[1];
+            if (/^(?:https?:|#)/.test(value)) continue;
+            const absolute = value.startsWith("/")
+                ? path.join(root, value.slice(1))
+                : path.resolve(path.dirname(sourcePath), value);
+            referencedPaths.add(path.relative(root, absolute).replaceAll("\\", "/"));
+        }
+    }
+}
+
+const missing = [...referencedPaths]
+    .map((file) => file.replace(/^[/\\]/, ""))
+    .filter((file) => !fs.existsSync(path.join(root, file)));
+
+if (missing.length) {
+    console.error("Extension validation failed. Missing referenced files:");
+    missing.forEach((file) => console.error(`- ${file}`));
+    process.exit(1);
+}
+
+console.log(`Extension validation passed (${referencedPaths.size} referenced files checked).`);

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -35,7 +35,7 @@
                 </svg>
                 <div class="rect"></div>
             </label>
-            <a class="github-repo-link" title="GitHub" href="https://github.com/Uri6/Genius-Enhancer/" target="_blank"
+            <a class="github-repo-link" title="GitHub" href="https://github.com/hackeagle/Genius-Enhancer/" target="_blank"
                 rel="noopener noreferrer">
                 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xLink" class="icon">
                     <path xmlns="http://www.w3.org/2000/svg" fill="grey"

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -38,7 +38,7 @@
                     <text x="50%" y="50%" text-anchor="middle" alignment-baseline="central">i</text>
                 </svg>
             </span>
-            <a class="github-repo-link" title="GitHub" href="https://github.com/Uri6/Genius-Enhancer/" target="_blank"
+            <a class="github-repo-link" title="GitHub" href="https://github.com/hackeagle/Genius-Enhancer/" target="_blank"
                 rel="noopener noreferrer">
                 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xLink" class="icon">
                     <path xmlns="http://www.w3.org/2000/svg"

--- a/src/js/extension/createSongMediaPlayers.js
+++ b/src/js/extension/createSongMediaPlayers.js
@@ -6,37 +6,27 @@
  */
 
 async function getDetails() {
-    // Find the first occurrence of a '<meta>' tag that contains a JSON string in its 'content' attribute
-    const metaElem = document.documentElement.innerHTML.match(
-        /<meta content="({[^"]+)/
-    );
+    for (const meta of document.querySelectorAll("meta[content]")) {
+        const content = meta.getAttribute("content")?.trim();
+        if (!content?.startsWith("{")) continue;
+        try {
+            const details = JSON.parse(content);
+            if (details.song || details.page_type) return details;
+        } catch {
+            // Continue looking for Genius page data.
+        }
+    }
 
-    // Define an object containing HTML entity codes and their corresponding characters
-    const replaces = {
-        "&#039;": `'`,
-        "&amp;": "&",
-        "&lt;": "<",
-        "&gt;": ">",
-        "&quot;": '"',
-    };
-
-    // If the '<meta>' tag was found, extract the JSON string from it and replace any HTML entities with their corresponding characters
-    if (metaElem) {
-        // Get the JSON string from the first '<meta>' tag, and replace any HTML entities using a callback function
-        const meta = metaElem[1].replace(
-            /&[\w\d#]{2,5};/g,
-            (match) => replaces[match]
-        );
-
-        // Parse the JSON string and return the resulting object
-        return JSON.parse(meta);
-    } else {
-        const id = document.querySelector("[property=\"twitter:app:url:iphone\"]").content.split("/")[3];
+    const appUrl = document.querySelector("[property=\"twitter:app:url:iphone\"]")?.content;
+    const id = appUrl?.split("/")[3];
+    if (id) {
         const response = await fetch(`https://genius.com/api/songs/${id}`);
+        if (!response.ok) return null;
         const json = await response.json();
-
         return json.response;
     }
+
+    return null;
 }
 
 function createSoundCloudPlayer(url) {
@@ -128,6 +118,12 @@ function createSoundCloudPlayer(url) {
 }
 
 async function createSpotifyPlayer() {
+    const clientId = globalThis.secrets?.SPOTIFY_CLIENT_ID;
+    const clientSecret = globalThis.secrets?.SPOTIFY_CLIENT_SECRET;
+    if (!clientId || !clientSecret) {
+        console.info("Spotify enhancement is unavailable until Spotify API credentials are configured.");
+        return;
+    }
     function genAuthBasicToken(clientId, clientSecret) {
         return btoa(`${clientId}:${clientSecret}`);
     }
@@ -364,7 +360,7 @@ async function createSpotifyPlayer() {
     }
 
     if (!document.getElementById("ge-spotify-player")) {
-        swapAppleMusicPlayer(secrets.SPOTIFY_CLIENT_ID, secrets.SPOTIFY_CLIENT_SECRET);
+        swapAppleMusicPlayer(clientId, clientSecret);
     }
 }
 

--- a/src/js/extension/defaultSecrets.js
+++ b/src/js/extension/defaultSecrets.js
@@ -1,0 +1,7 @@
+// Optional local-only integration credentials. Never commit real credentials.
+// Core Genius Enhancer features remain available when these values are blank.
+window.secrets ??= {
+    SPOTIFY_CLIENT_ID: "",
+    SPOTIFY_CLIENT_SECRET: "",
+    GOOGLE_API_KEY: ""
+};

--- a/src/js/extension/popup.js
+++ b/src/js/extension/popup.js
@@ -122,7 +122,7 @@ chrome.tabs.query({ active: true, currentWindow: true }, async () => {
     handleCheckboxClick("apple-music-pop-up", "appleMusicPopUp", "song_appleMusicPopUp");
     handleCheckboxClick("spotify-pop-up", "spotifyPopUp", "song_spotifyPopUp");
     handleCheckboxClick("soundcloud-pop-up", "soundCloudPopUp", "song_soundCloudPopUp");
-    handleCheckboxClick("modern-text-editor", "ModernTextEditor", "song_ModernTextEditor");
+    handleCheckboxClick("modern-text-editor", "ModernTextEditor", "song_modernTextEditor");
     handleCheckboxClick("old-song-page", "OldSongPage", "");
 
     // create and add album elements
@@ -138,7 +138,7 @@ chrome.tabs.query({ active: true, currentWindow: true }, async () => {
         .append(FORUMS_ELEMENT)
         .append(FORUMS_FEATURES_ELEMENT);
     handleCheckboxClick("modernForums", "modernForums", "");
-    handleCheckboxClick("modern-text-editor", "ModernTextEditor", "song_ModernTextEditor");
+    handleCheckboxClick("modern-text-editor", "ModernTextEditor", "song_modernTextEditor");
 
     // allow navigation through pages using arrow keys
     $(document).keydown((e) => {

--- a/src/js/extension/utils.js
+++ b/src/js/extension/utils.js
@@ -42,11 +42,12 @@ export function handleCheckboxClick(checkboxId, storageKey = checkboxId, message
 
     $checkbox.click(() => {
         const isChecked = $checkbox.prop("checked");
-        const altMessageKey = isChecked ? "album_missingInfo" : "album_missingInfo_remove";
-        const updateMessageKey = messageKey.length ? messageKey : altMessageKey;
-
         chrome.storage.local.set({ [storageKey]: isChecked });
-        chrome.runtime.sendMessage({ [updateMessageKey]: messageValue || [isChecked] });
+        if (messageKey || messageValue) {
+            const altMessageKey = isChecked ? "album_missingInfo" : "album_missingInfo_remove";
+            const updateMessageKey = messageKey.length ? messageKey : altMessageKey;
+            chrome.runtime.sendMessage({ [updateMessageKey]: messageValue || [isChecked] });
+        }
 
         getAndUpdateState();
     });

--- a/src/js/pages/album.js
+++ b/src/js/pages/album.js
@@ -17,6 +17,26 @@ export async function handleAlbum(tabId) {
         {
             target: { tabId: tabId },
             func: (async () => {
+                const oldAlbumPageButton = [...document.querySelectorAll("button")]
+                    .find((button) => button.textContent.trim() === "View Old Album Page");
+
+                if (oldAlbumPageButton) {
+                    if (!document.querySelector(".ge-bulk-edit-credits")) {
+                        const bulkEditButton = oldAlbumPageButton.cloneNode(true);
+                        bulkEditButton.classList.add("ge-bulk-edit-credits");
+                        bulkEditButton.textContent = "Bulk edit credits";
+                        bulkEditButton.title = "Open the compatible album editor";
+                        bulkEditButton.addEventListener("click", () => {
+                            oldAlbumPageButton.click();
+                        });
+                        oldAlbumPageButton.parentNode.insertBefore(
+                            bulkEditButton,
+                            oldAlbumPageButton
+                        );
+                    }
+                    return;
+                }
+
                 $("div[ng-bind-html='metadata_question.question']").each((index, e) => {
                     e.parentElement.remove();
                 });
@@ -89,15 +109,17 @@ export async function handleAlbum(tabId) {
                 }
 
                 // Get the album title and artist name from the page DOM
-                const title = document.getElementsByClassName("header_with_cover_art-primary_info-title header_with_cover_art-primary_info-title--white")[0].innerText;
-                const artist = document.getElementsByClassName("header_with_cover_art-primary_info-primary_artist")[0].innerText;
+                const title = document.querySelector(".header_with_cover_art-primary_info-title, [class*='HeaderAlbum__Title']")?.innerText;
+                const artist = document.querySelector(".header_with_cover_art-primary_info-primary_artist, [class*='HeaderArtistAndTracklistdesktop__Artist']")?.innerText;
                 const query = [title, artist];
 
-                const albumArtworks = await new Promise((resolve) => {
-                    chrome.runtime.sendMessage({ "album_autolinkArtwork": [query, "album", true] }, (response) => {
-                        resolve(response);
-                    });
-                });
+                const albumArtworks = title && artist
+                    ? await new Promise((resolve) => {
+                        chrome.runtime.sendMessage({ "album_autolinkArtwork": [query, "album", true] }, (response) => {
+                            resolve(Array.isArray(response) ? response : []);
+                        });
+                    })
+                    : [];
 
                 const albumArtworksContainer = $("<datalist>", {
                     id: "albumArtworks",
@@ -113,6 +135,7 @@ export async function handleAlbum(tabId) {
                 }
 
                 getTagsList().then(res => {
+                    if (!res) return;
                     const replaces = {
                         "&#039;": `'`,
                         "&amp;": "&",
@@ -145,6 +168,8 @@ export async function handleAlbum(tabId) {
                     });
 
                     $("body").append(dataListElem);
+                }).catch((error) => {
+                    console.info("Legacy Genius tag list is unavailable", error);
                 });
 
                 const albumObject = await new Promise((resolve) => {
@@ -153,7 +178,9 @@ export async function handleAlbum(tabId) {
                     });
                 });
 
-                const isExplicit = albumObject.dfp_kv.find(x => x.name === "is_explicit").values[0] === "true";
+                const isExplicit = albumObject?.dfp_kv
+                    ?.find(x => x.name === "is_explicit")
+                    ?.values?.[0] === "true";
 
                 if (isExplicit && !$(".ge-explicit-icon").length) {
                     $(".header_with_cover_art-primary_info-title").append($("<img>", {

--- a/src/js/pages/forumThread.js
+++ b/src/js/pages/forumThread.js
@@ -98,35 +98,29 @@ export async function handleForumThread(tabId) {
                                 return;
                             }
                             const username = iqValue.getAttribute("href").slice(1);
-                            const quillEditor = $(".ql-editor");
-                            if (quillEditor.length === 0) {
-                                console.error("no quill editor");
+                            const nativeEditor = $("#forum_post_body, textarea.required.markdown_preview_setup_complete");
+                            if (nativeEditor.length === 0) {
+                                console.error("no forum editor");
                                 return;
                             }
-                            const existingText = quillEditor.html();
+                            const existingText = nativeEditor.val() || "";
                             if (existingText.includes("@" + username + " ")) {
                                 return;
                             }
                             const taggedUsernames = existingText.match(/@\w+\s/g) || [];
-                            if (taggedUsernames.length > 0) {
-                                quillEditor.append("\n@" + username + " \n\n");
-                            } else {
-                                quillEditor.prepend("@" + username + " \n\n");
-                            }
+                            const mention = "@" + username + " \n\n";
+                            nativeEditor.val(taggedUsernames.length > 0
+                                ? existingText + "\n" + mention
+                                : mention + existingText
+                            ).trigger("input").trigger("change");
 
                             $("html, body").animate({
-                                scrollTop: quillEditor.offset().top
+                                scrollTop: nativeEditor.offset().top
                             }, 500);
 
-                            quillEditor.trigger("focus");
-
-                            // set the cursor to the end of the text
-                            const range = document.createRange();
-                            const sel = window.getSelection();
-                            range.setStart(quillEditor[0], quillEditor[0].childNodes.length);
-                            range.collapse(true);
-                            sel.removeAllRanges();
-                            sel.addRange(range);
+                            nativeEditor.trigger("focus");
+                            const editor = nativeEditor[0];
+                            editor.setSelectionRange(editor.value.length, editor.value.length);
                         });
 
                         forumPostUnit.appendChild(replyButton);

--- a/src/js/pages/newPost.js
+++ b/src/js/pages/newPost.js
@@ -11,7 +11,8 @@ export async function handleNewPost(tabId) {
     });
 
     await chrome.scripting.executeScript({
-        target: { tabId: tabId }, func: () => {
+        target: { tabId },
+        func: () => {
             chrome.storage.local.get("ModernTextEditor", (res) => {
                 if (res.ModernTextEditor) {
                     chrome.runtime.sendMessage({ "forums_modernTextEditor": [true] });

--- a/src/js/pages/song.js
+++ b/src/js/pages/song.js
@@ -23,14 +23,12 @@ export async function handleSongPage(tabId) {
 	chrome.storage.local.get("ModernTextEditor", (res) => {
 		if (res.ModernTextEditor) {
 			chrome.scripting.executeScript({
-				target: {
-					tabId: tabId
-				},
-				func: (() => {
+				target: { tabId },
+				func: () => {
 					chrome.runtime.sendMessage({
 						"song_modernTextEditor": [true]
 					});
-				})
+				}
 			});
 		}
 	});
@@ -150,7 +148,7 @@ export async function handleSongPage(tabId) {
 								});
 							});
 
-							if (ytURL.length > 0) {
+							if (ytURL) {
 								// Clear any previous search results
 								const youtubeInput = document.querySelectorAll("section.ScrollableTabs__Section-sc-179ldtd-6[data-section-index='1'] input.TextInput-sc-2wssth-0")[0];
 								youtubeInput.value = "";

--- a/src/js/powerbar.js
+++ b/src/js/powerbar.js
@@ -5,10 +5,26 @@
  * https://github.com/Uri6/Genius-Enhancer/blob/main/LICENSE.md
  */
 
+(() => {
+if (globalThis.__geniusEnhancerPowerbarLoaded) {
+    return;
+}
+globalThis.__geniusEnhancerPowerbarLoaded = true;
+
 // Create a new AbortController for the search request
 let searchController = new AbortController();
 
 insertPowerbar();
+
+async function getStoredSettings(keys) {
+    if (!chrome.runtime?.id) return null;
+    try {
+        return await chrome.storage.local.get(keys);
+    } catch (error) {
+        if (String(error).includes("Extension context invalidated")) return null;
+        throw error;
+    }
+}
 
 // Placeholder texts for the powerbar input
 const placeholders = [
@@ -48,7 +64,9 @@ window.addEventListener("keyup", async (e) => {
     }
 
     // Retrieve the hotkey combination and split it into individual keys
-    let powerbarHotkey = (await chrome.storage.local.get("powerbarHotkey"))?.powerbarHotkey || "Shift + Shift";
+    const hotkeySettings = await getStoredSettings("powerbarHotkey");
+    if (!hotkeySettings) return;
+    let powerbarHotkey = hotkeySettings.powerbarHotkey || "Shift + Shift";
     let keys = powerbarHotkey.split(" + ").map(key => key.toLowerCase().replace("space", " ").replace("ctrl", "control"));
 
     // Normalize the key pressed
@@ -76,19 +94,19 @@ window.addEventListener("keyup", async (e) => {
 
     // Toggle the powerbar if all keys are pressed
     if (allKeysPressed) {
-        chrome.storage.local.get(["powerbarStatus"], (res) => {
-            if (res.powerbarStatus) {
-                e.preventDefault();
-                $("#powerbar-input").val("");
-                $("#powerbar-results").remove();
-                $("#ge-powerbar").toggle();
-                $("#powerbar-input").attr("placeholder", placeholders[Math.floor(Math.random() * placeholders.length)]);
-                if ($("#ge-powerbar").is(":visible")) {
-                    $("#powerbar-input").focus();
-                }
-                keyPressStatus = [false, false, false];
+        const settings = await getStoredSettings("powerbarStatus");
+        if (!settings) return;
+        if (settings.powerbarStatus) {
+            e.preventDefault();
+            $("#powerbar-input").val("");
+            $("#powerbar-results").remove();
+            $("#ge-powerbar").toggle();
+            $("#powerbar-input").attr("placeholder", placeholders[Math.floor(Math.random() * placeholders.length)]);
+            if ($("#ge-powerbar").is(":visible")) {
+                $("#powerbar-input").focus();
             }
-        });
+            keyPressStatus = [false, false, false];
+        }
     }
 });
 
@@ -268,7 +286,7 @@ async function search(query, type = "unset") {
 
     if (type === "unset") {
         // Get the default search type from the storage
-        type = (await chrome.storage.local.get("defaultSearchType"))?.defaultSearchType || "multi";
+        type = (await getStoredSettings("defaultSearchType"))?.defaultSearchType || "multi";
     }
 
     addLoadingAnimation();
@@ -386,7 +404,7 @@ async function displaySearchResults(results) {
             class: "scroll-container"
         }));
 
-    const openInNewTab = (await chrome.storage.local.get("openPowerbarResultsInNewTab"))?.openPowerbarResultsInNewTab || false;
+    const openInNewTab = (await getStoredSettings("openPowerbarResultsInNewTab"))?.openPowerbarResultsInNewTab || false;
 
     // Iterate over the results and create a card for each one
     results.forEach((result) => {
@@ -522,3 +540,5 @@ function displayCommandResults(options) {
 function hidePage(id, type) {
 
 }
+
+})();

--- a/src/js/sideFunctions/album.js
+++ b/src/js/sideFunctions/album.js
@@ -45,7 +45,7 @@ export async function missingInfo(bio, people, releaseDate) {
     const tracklist = document.getElementsByClassName("chart_row chart_row--light_border chart_row--full_bleed_left chart_row--align_baseline chart_row--no_hover");
     let song_index = 0;
 
-    if (albumObject.album_appearances.length === 0) {
+    if (!albumObject?.album_appearances?.length || !tracklist.length) {
         return;
     }
 
@@ -69,7 +69,7 @@ export async function missingInfo(bio, people, releaseDate) {
         createIcon(imgs.bios[song.description_preview === "" ? "missing" : "exists"], song.description_preview === "" ? "missing bio" : "exists bio", song.description_preview === "" ? "No one has written a bio for this song yet" : "", bioClasses);
         createIcon(imgs.releaseDate[song.release_date_for_display ? "exists" : "missing"], song.release_date_for_display ? "exists release date" : "missing release date", !song.release_date_for_display ? "The release date for this song is unknown" : "", releaseDateClasses);
 
-        elem.appendChild(iconContainer[0]);
+        elem?.appendChild(iconContainer[0]);
         song_index++;
     });
 }
@@ -101,7 +101,10 @@ export async function getPlaylistVideos(playlistLink) {
     }
 
     const playlistId = new URL(playlistLink).searchParams.get("list");
-    const key = secrets.GOOGLE_API_KEY;
+    const key = globalThis.secrets?.GOOGLE_API_KEY;
+    if (!key) {
+        return "getPlaylistVideos: Google API key is not configured";
+    }
 
     const metadataResponse = await fetch(`https://www.googleapis.com/youtube/v3/playlists?part=snippet&id=${playlistId}&key=${key}`);
     if (!metadataResponse.ok) {
@@ -946,28 +949,36 @@ export async function appendIcon() {
             }
         });
 
-        async function waitForTagsList() {
+        async function waitForTagsList(maxAttempts = 3) {
             const tagsList = $("datalist#tagsList");
             if (tagsList.children("option").length > 0) {
                 $("input.add-tags.rcorners.ge-textarea").attr("placeholder", "Tag");
                 $("input.add-tags.rcorners.ge-textarea").removeAttr("disabled");
                 $("input.add-tags.rcorners.ge-textarea").css("cursor", "default");
-                return;
+                return true;
             }
             const inputElem = $("input.add-tags.rcorners.ge-textarea");
-            inputElem.attr("placeholder", "Loading.");
             inputElem.attr("disabled", true);
             inputElem.css("cursor", "not-allowed");
-            await new Promise(resolve => setTimeout(resolve, 500));
-            inputElem.attr("placeholder", "Loading..");
-            await new Promise(resolve => setTimeout(resolve, 500));
-            inputElem.attr("placeholder", "Loading...");
-            await new Promise(resolve => setTimeout(resolve, 500));
-            inputElem.attr("placeholder", "Loading.");
-            await waitForTagsList();
+
+            for (let attempt = 0; attempt < maxAttempts; attempt++) {
+                inputElem.attr("placeholder", `Loading${".".repeat((attempt % 3) + 1)}`);
+                await new Promise(resolve => setTimeout(resolve, 300));
+                if ($("datalist#tagsList option").length > 0) {
+                    inputElem.attr("placeholder", "Tag");
+                    inputElem.removeAttr("disabled");
+                    inputElem.css("cursor", "default");
+                    return true;
+                }
+            }
+
+            inputElem.attr("placeholder", "Type to search tags");
+            inputElem.removeAttr("disabled");
+            inputElem.css("cursor", "default");
+            return false;
         }
 
-        await waitForTagsList();
+        const tagsAvailable = await waitForTagsList();
 
         const tagify_tagsWhitelist = $("datalist#tagsList option").map(function(_, o) {
             let searchByStr;
@@ -1026,8 +1037,40 @@ export async function appendIcon() {
             }
         });
 
-        $("#tagify_tags").on("input", (e) => {
+        let tagSearchController;
+        tagify_tags.on("input", async (event) => {
+            const query = event.detail.value.trim();
             $(".blured-background").append($(".tagify__dropdown").eq(0));
+
+            if (tagsAvailable || query.length < 1) {
+                return;
+            }
+
+            tagSearchController?.abort();
+            tagSearchController = new AbortController();
+
+            try {
+                const response = await fetch(
+                    `/api/tags/autocomplete?q=${encodeURIComponent(query)}`,
+                    { signal: tagSearchController.signal }
+                );
+                if (!response.ok) {
+                    throw new Error(`Tag search failed (${response.status})`);
+                }
+
+                const data = await response.json();
+                const tags = data.response?.tags || data.tags || [];
+                tagify_tags.whitelist = tags.map((tag) => ({
+                    value: tag.name,
+                    id: tag.id
+                }));
+                tagify_tags.dropdown.show(query);
+                $(".blured-background").append($(".tagify__dropdown").eq(0));
+            } catch (error) {
+                if (error.name !== "AbortError") {
+                    console.error("Unable to search Genius tags", error);
+                }
+            }
         });
 
         if ($("#tagsList").length) {

--- a/src/js/sideFunctions/forum.js
+++ b/src/js/sideFunctions/forum.js
@@ -124,7 +124,7 @@ export function forums_modernTextEditor() {
         $("#new_discussion .required.markdown_preview_setup_complete").length
     ) {
         chrome.runtime.sendMessage({
-            replaceTextarea: ["required markdown_preview_setup_complete"],
+            replaceTextarea: [".required.markdown_preview_setup_complete"],
         });
 
         if ($(".reply_container .formatting_help").length) {

--- a/src/js/sideFunctions/global.js
+++ b/src/js/sideFunctions/global.js
@@ -47,31 +47,23 @@ export function insertAfter(newNode, existingNode) {
  * @returns The parsed metadata object
  */
 export function getDetails() {
-    // Find the first occurrence of a '<meta>' tag that contains a JSON string in its 'content' attribute
-    const metaElem = document.documentElement.innerHTML.match(
-        /<meta content="({[^"]+)/
-    );
+    for (const meta of document.querySelectorAll("meta[content]")) {
+        const content = meta.getAttribute("content")?.trim();
+        if (!content?.startsWith("{")) {
+            continue;
+        }
 
-    // Define an object containing HTML entity codes and their corresponding characters
-    const replaces = {
-        "&#039;": `'`,
-        "&amp;": "&",
-        "&lt;": "<",
-        "&gt;": ">",
-        "&quot;": '"',
-    };
-
-    // If the '<meta>' tag was found, extract the JSON string from it and replace any HTML entities with their corresponding characters
-    if (metaElem) {
-        // Get the JSON string from the first '<meta>' tag, and replace any HTML entities using a callback function
-        const meta = metaElem[1].replace(
-            /&[\w\d#]{2,5};/g,
-            (match) => replaces[match]
-        );
-
-        // Parse the JSON string and return the resulting object
-        return JSON.parse(meta);
+        try {
+            const details = JSON.parse(content);
+            if (details.page_type || details.song || details.album_appearances) {
+                return details;
+            }
+        } catch {
+            // Most metadata is not JSON. Continue looking for Genius page data.
+        }
     }
+
+    return null;
 }
 
 /**
@@ -291,21 +283,28 @@ export async function getCreditsList(query) {
 /**
  * Replaces a textarea with a Quill rich text editor
  *
- * @param {string} textareaClasses - The classes of the textarea to replace
+ * @param {string} textareaSelector - A selector for the textarea to replace
  * @throws {Error} - Throws an error if the textarea could not be found
  * @returns {void}
  */
-export function replaceTextarea(textareaClasses) {
+export function replaceTextarea(textareaSelector) {
     if ($(".ql-editor").length) {
         console.info("Quill already exists");
         return;
     }
 
-    const textarea = document.getElementsByClassName(textareaClasses)[0];
+    const textarea = document.querySelector(textareaSelector) ||
+        document.getElementsByClassName(textareaSelector)[0];
     if (!textarea) {
-        throw new Error("could not find textarea");
+        console.info("Genius Enhancer could not find an editor textarea.");
+        return;
     }
-    let content = textarea.value;
+    if (textarea.dataset.geniusEnhancerEditor === "true") return;
+    textarea.dataset.geniusEnhancerEditor = "true";
+    const isContentEditable = textarea.isContentEditable;
+    let content = isContentEditable
+        ? textarea.innerHTML
+        : textarea.value;
     textarea.style.display = "none";
     const editor = document.createElement("div");
     textarea.parentNode.appendChild(editor);
@@ -365,7 +364,8 @@ export function replaceTextarea(textareaClasses) {
     });
 
     // if editing lyrics, it's making the header sticky
-    if (textareaClasses !== "required markdown_preview_setup_complete") {
+    const isForumEditor = textarea.matches(".required.markdown_preview_setup_complete");
+    if (!isForumEditor) {
         const toolbar = $(".ql-toolbar");
         const toolbarHeight = toolbar.height();
         const toolbarContainer = $("<div>", { class: "ql-toolbar-container" });
@@ -425,16 +425,23 @@ export function replaceTextarea(textareaClasses) {
             .replace(/<\/b>\n<b>/g, "\n")
             .replace(/<\/i>\n<i>/g, "\n");
 
-        textarea.value = markdownFormat;
+        if (isContentEditable) {
+            textarea.innerHTML = markdownFormat;
+        } else {
+            textarea.value = markdownFormat;
+        }
 
-        const event = new Event("input", {
+        const inputEvent = new InputEvent("input", {
             bubbles: true,
             cancelable: true,
+            inputType: "insertText",
+            data: null
         });
-        textarea.dispatchEvent(event);
+        textarea.dispatchEvent(inputEvent);
+        textarea.dispatchEvent(new Event("change", { bubbles: true }));
     });
 
-    if (textareaClasses === "required markdown_preview_setup_complete") {
+    if (isForumEditor) {
         window.scrollTo(0, 0);
     }
 }

--- a/src/js/sideFunctions/song.js
+++ b/src/js/sideFunctions/song.js
@@ -49,25 +49,40 @@ export function soundCloudPopUp(show) {
  * @returns {void}
  */
 export function song_modernTextEditor() {
-    document.addEventListener("DOMNodeInserted", (e) => {
-        if (e.target.className === "ExpandingTextarea__Textarea-sc-4cgivl-0 kYxCOo") {
-            // Remove the Quill toolbar container from the DOM
-            if ($(".ql-toolbar-container").length) {
-                $(".ql-toolbar-container").remove();
-            }
+    const selector = [
+        "form[aria-label='Edit Lyrics Form'] textarea",
+        "[data-react-modal-body-trap] textarea",
+        "[role='dialog'] textarea",
+        "[data-react-modal-body-trap] [contenteditable='true'][role='textbox']",
+        "[role='dialog'] [contenteditable='true'][role='textbox']",
+        "textarea[class*='LyricsEdit']",
+        "textarea[class*='ExpandingTextarea']",
+        "textarea[data-testid*='lyrics']",
+        "textarea[name*='lyrics']",
+        "textarea[aria-label*='lyrics' i]"
+    ].join(", ");
 
-            // Loop through all elements with class "ql-snow" and remove them from the DOM
-            while ($(".ql-snow").length) {
-                $(".ql-snow").remove();
-            }
+    const initializeEditor = () => {
+        const textarea = [...document.querySelectorAll(selector)]
+            .find((element) => element.getClientRects().length > 0);
+        if (!textarea || textarea.dataset.geniusEnhancerEditor === "true") return;
 
-            chrome.runtime.sendMessage({
-                replaceTextarea: [
-                    "ExpandingTextarea__Textarea-sc-4cgivl-0 kYxCOo"
-                ]
-            });
-        }
+        $(".ql-toolbar-container, .ql-toolbar, .ql-container").remove();
+        chrome.runtime.sendMessage({
+            replaceTextarea: [selector]
+        });
+    };
+
+    initializeEditor();
+    const observer = new MutationObserver(initializeEditor);
+    observer.observe(document.body, {
+        childList: true,
+        subtree: true
     });
+
+    window.addEventListener("pagehide", () => {
+        observer.disconnect();
+    }, { once: true });
 }
 
 /**
@@ -77,18 +92,25 @@ export function song_modernTextEditor() {
  * @returns {Promise<string>} - A Promise that resolves to the URL of the most relevant video for the given search query
  */
 export async function searchVideo(query) {
-    // TODO: don't hardcode the API key
-    const key = secrets.GOOGLE_API_KEY;
+    const key = globalThis.secrets?.GOOGLE_API_KEY;
+    if (!key) {
+        console.info("YouTube search is unavailable until a Google API key is configured.");
+        return null;
+    }
 
     try {
         const response = await fetch(
             `https://www.googleapis.com/youtube/v3/search?part=id&q=${encodeURIComponent(query)}&type=video&order=relevance&key=${key}`
         );
         const data = await response.json();
-        const [{ id: { videoId } }] = data.items;
+        const videoId = data.items?.[0]?.id?.videoId;
+        if (!videoId) {
+            return null;
+        }
         return `https://www.youtube.com/watch?v=${videoId}`;
     } catch (error) {
         console.error(error);
+        return null;
     }
 }
 
@@ -98,7 +120,12 @@ export async function reactSongAdditions() {
     const classBase = "ContributorSidebarSection__Container-";
     const completeTheSongLyrics = document.querySelectorAll("[class^=\"" + classBase + "\"], [class*=\" " + classBase + "\"]")[0];
 
-    const id = document.querySelector("[property=\"twitter:app:url:iphone\"]").content.split("/")[3];
+    const appUrl = document.querySelector("[property=\"twitter:app:url:iphone\"]")?.content;
+    const id = appUrl?.split("/")[3];
+    if (!id) {
+        console.info("Genius Enhancer could not determine the current song ID.");
+        return;
+    }
     const parseCookies = () => {
         return Object.fromEntries(
             document.cookie.split("; ").map(cookie => {
@@ -119,7 +146,7 @@ export async function reactSongAdditions() {
 
     const checky = `<svg class="ge-checky" fill="currentColor" width="16" height="16" viewBox="0 0 18 19" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4 2.017a9 9 0 1 1 10 14.966A9 9 0 0 1 4 2.017Zm.714 13.897a7.715 7.715 0 1 0 8.572-12.829 7.715 7.715 0 0 0-8.572 12.83ZM4.5 9.765l3.214 3.215L13.5 7.195l-.91-.91-4.876 4.877-2.306-2.305-.908.909Z" clip-rule="evenodd"></path></svg>`;
 
-    if (song.verified_contributors.length > 0) {
+    if (completeTheSongLyrics && song.verified_contributors?.length > 0) {
         const lyricVerifiers = song.verified_contributors.filter(contrib => (
             contrib.contributions.includes("lyrics")
         ));
@@ -138,8 +165,7 @@ export async function reactSongAdditions() {
     }
 
     if (toolbarContainer && !document.querySelector("#ge-follow-button")) {
-        const id = document.querySelector("[property=\"twitter:app:url:iphone\"]").content.split("/")[3];
-        const currentStatus = song.current_user_metadata.interactions.following;
+        const currentStatus = song.current_user_metadata?.interactions?.following || false;
 
         const button = document.createElement("input");
         button.type = "checkbox";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         /* Visit https://aka.ms/tsconfig to read more about this file */
-        "composite": true,
+        "composite": false,
         "target": "ES2019",
         "lib": ["ES2021", "DOM", "DOM.Iterable"],
         "module": "ES2022",
@@ -14,6 +14,6 @@
         "strictNullChecks": false,
         "strict": false,
         "noImplicitAny": false,
-        "skipLibCheck": false
+        "skipLibCheck": true
     }
 }


### PR DESCRIPTION
## Summary

Restores the Genius Enhancer Chrome extension for current Genius.com pages and Manifest V3 behavior, while keeping testing and validation read-only.

## What changed

- Repaired extension startup and service-worker behavior.
- Added safer default settings initialization so missing stored settings do not break the extension.
- Improved Manifest V3 script/CSS injection guards to avoid injecting into unsupported pages.
- Fixed Genius page detection for songs, albums, forums, posts, and editor pages.
- Updated modern Genius editor detection so the enhanced lyrics editor can attach to the current Genius textarea structure.
- Restored album-page bulk editing entry points, including a bridge from the modern album page to the old album page where bulk credits/tags still work.
- Fixed album bulk tag loading by switching from the removed old tag datalist flow to Genius’s current tag autocomplete API.
- Made Spotify/Google/YouTube credentials optional so missing secrets fail gracefully instead of disabling unrelated features.
- Added a safe default secrets file.
- Hardened media-player creation and utility helpers so missing page elements or credentials do not crash unrelated features.
- Fixed popup/options script references.
- Wrapped the powerbar script to avoid duplicate global declarations after SPA navigation/re-injection.
- Added repeatable extension validation via `scripts/validate-extension.js`.
- Reworked Sass compilation scripts so builds work reliably from paths with spaces.
- Updated README instructions for build, validation, packaging, local credentials, and safe testing expectations.
- Adjusted TypeScript settings to allow the current extension codebase to check cleanly.

## Safe testing approach

Testing was done without saving or modifying Genius.com data.

- Opened public Genius pages and editor pages only for inspection.
- Verified page detection and UI injection behavior without submitting editor changes.
- Exercised generated editor content locally but did not click save/submit.
- Restored album bulk-edit UI paths while preserving the rule that actual saves are outside acceptance testing unless separately authorized.
- Validated extension files and referenced assets locally.

## Validation

- `tsc --noEmit`
- `node scripts/validate-extension.js`

Result:

```text
Extension validation passed (76 referenced files checked).